### PR TITLE
added all the solver in fasp solver

### DIFF
--- a/include/fasp_to_fenics.h
+++ b/include/fasp_to_fenics.h
@@ -8,6 +8,7 @@
 
 #include <iostream>
 #include <dolfin.h>
+// #include "LinearVariationalProblem.h"
 extern "C"
 {
 #include "fasp.h"
@@ -34,5 +35,13 @@ void copy_dvector_to_Function(const dvector* vec_b, dolfin::Function* F);
 void get_dofs(dolfin::Function* vector_function, ivector* dof_array, unsigned int component);
 
 void copy_dvector_to_vector_function(const dvector* vector, dolfin::Function* F, ivector* vector_dofs, ivector* function_dofs);
+
+void solve_dcsr_fasp(const dolfin::Form& a, const dolfin::Form& L, dolfin::EigenVector* Solution, const dolfin::DirichletBC bc, itsolver_param itpar);
+
+void solve_dcsr_fasp(const dolfin::Form& a, const dolfin::Form& L, dolfin::EigenVector* Solution, std::vector<const dolfin::DirichletBC*> bcs, itsolver_param itpar);
+
+void solve_dbsr_fasp(int block, const dolfin::Form& a, const dolfin::Form& L, dolfin::EigenVector* Solution, dolfin::DirichletBC bc, itsolver_param itpar, AMG_param amgpar);
+
+void solve_dbsr_fasp(int block, const dolfin::Form& a, const dolfin::Form& L, dolfin::EigenVector* Solution, std::vector<const dolfin::DirichletBC*> bcs, itsolver_param itpar, AMG_param amgpar);
 
 #endif

--- a/tests/faspsolver_tests/test_faspsolver.cpp
+++ b/tests/faspsolver_tests/test_faspsolver.cpp
@@ -159,14 +159,14 @@ int main(int argc, char** argv)
   if (DEBUG) printf("done\n"); fflush(stdout);
 
   /// FASP Solver
-  dCSRmat A_fasp;
-  dvector b_fasp;
-  dvector Solu_fasp;
-  EigenVector_to_dvector(&b,&b_fasp);
-  EigenMatrix_to_dCSRmat(&A,&A_fasp);
-  fasp_dvec_alloc(b_fasp.row, &Solu_fasp);
-  fasp_dvec_set(b_fasp.row, &Solu_fasp, 0.0);
-  if (DEBUG) printf("Solve the Poisson's equation using FASP..."); fflush(stdout);
+  // dCSRmat A_fasp;
+  // dvector b_fasp;
+  // dvector Solu_fasp;
+  // EigenVector_to_dvector(&b,&b_fasp);
+  // EigenMatrix_to_dCSRmat(&A,&A_fasp);
+  // fasp_dvec_alloc(b_fasp.row, &Solu_fasp);
+  // fasp_dvec_set(b_fasp.row, &Solu_fasp, 0.0);
+  // if (DEBUG) printf("Solve the Poisson's equation using FASP..."); fflush(stdout);
   input_param inpar;
   itsolver_param itpar;
   AMG_param amgpar;
@@ -175,7 +175,10 @@ int main(int argc, char** argv)
   fasp_param_input(inputfile, &inpar);
   fasp_param_init(&inpar, &itpar, &amgpar, &ilupar, NULL);
   INT status = FASP_SUCCESS;
-  status = fasp_solver_dcsr_krylov(&A_fasp, &b_fasp, &Solu_fasp, &itpar);
+  // status = fasp_solver_dcsr_krylov(&A_fasp, &b_fasp, &Solu_fasp, &itpar);
+  EigenVector EigenSolu(V.dim());
+  EigenSolu.zero();
+  solve_dcsr_fasp(a, L, &EigenSolu, bc, itpar);
   if (DEBUG)  printf("done\n"); fflush(stdout);
 
   Solution ExactSolu;
@@ -188,8 +191,8 @@ int main(int argc, char** argv)
   double error_norm1 = 0.0;
   double error_norm2 = 0.0;
   double error_norm3 = 0.0;
-  copy_dvector_to_Function(&Solu_fasp,&Error1);
-  copy_dvector_to_Function(&Solu_fasp,&Error2);
+  *(Error1.vector())=EigenSolu;
+  *(Error2.vector())=EigenSolu;
   *(Error3.vector())=Solu_vec;
 
   if (DEBUG){

--- a/tests/linearized_pnp_tests/test_lin_pnp.cpp
+++ b/tests/linearized_pnp_tests/test_lin_pnp.cpp
@@ -164,24 +164,10 @@ int main(int argc, char** argv)
   cationSolution.interpolate(Cation);
   Function anionSolution(solutionFunction[1]);
   anionSolution.interpolate(Anion);
-  ivector cation_dofs;
-  ivector anion_dofs;
-  ivector potential_dofs;
-  get_dofs(&solutionFunction, &cation_dofs, 0);
-  get_dofs(&solutionFunction, &anion_dofs, 1);
-  get_dofs(&solutionFunction, &potential_dofs, 2);
 
   // Solve for consistent voltage : not yet implemented
   Function potentialSolution(solutionFunction[2]);
   potentialSolution.interpolate(Volt);
-
-  // initialize linear system
-  if (DEBUG) printf("\tlinear algebraic objects...\n");
-  EigenMatrix A_pnp;
-  EigenVector b_pnp;
-  dCSRmat A_fasp;
-  dBSRmat A_fasp_bsr;
-  dvector b_fasp, solu_fasp;
 
   // Setup FASP solver
   if (DEBUG) printf("\tsetup FASP solver...\n");
@@ -207,6 +193,7 @@ int main(int argc, char** argv)
   L_pnp.CatCat = cationSolution;
   L_pnp.AnAn = anionSolution;
   L_pnp.EsEs = potentialSolution;
+  EigenVector b_pnp;
   assemble(b_pnp, L_pnp);
   bc.apply(b_pnp);
   double initial_residual = b_pnp.norm("l2");
@@ -227,26 +214,18 @@ int main(int argc, char** argv)
   a_pnp.CatCat = cationSolution;
   a_pnp.AnAn = anionSolution;
   a_pnp.EsEs = potentialSolution;
-  assemble(A_pnp, a_pnp);
-  bc.apply(A_pnp);
+  // assemble(A_pnp, a_pnp);
+  // bc.apply(A_pnp);
 
   // Convert to fasp
   if (DEBUG) printf("\tconvert to FASP and solve...\n");
-  EigenVector_to_dvector(&b_pnp,&b_fasp);
-  EigenMatrix_to_dCSRmat(&A_pnp,&A_fasp);
-  A_fasp_bsr = fasp_format_dcsr_dbsr(&A_fasp, 3);
-  fasp_dvec_alloc(b_fasp.row, &solu_fasp);
-  fasp_dvec_set(b_fasp.row, &solu_fasp, 0.0);
-  status = fasp_solver_dbsr_krylov_amg(&A_fasp_bsr, &b_fasp, &solu_fasp, &itpar, &amgpar);
-
-  // map solu_fasp into solutionUpdate
-  if (DEBUG) printf("\tconvert FASP solution to function...\n");
-  copy_dvector_to_vector_function(&solu_fasp, &solutionUpdate, &cation_dofs, &cation_dofs);
-  copy_dvector_to_vector_function(&solu_fasp, &solutionUpdate, &anion_dofs, &anion_dofs);
-  copy_dvector_to_vector_function(&solu_fasp, &solutionUpdate, &potential_dofs, &potential_dofs);
+  EigenVector EigenSolu(V.dim());
+  EigenSolu.zero();
+  solve_dbsr_fasp(3, a_pnp, L_pnp, &EigenSolu, bc, itpar,amgpar);
 
   // update solution and reset solutionUpdate
   if (DEBUG) printf("\tupdate solution...\n");
+  *(solutionUpdate.vector())=EigenSolu;
   update_solution(&cationSolution, &solutionUpdate[0]);
   update_solution(&anionSolution, &solutionUpdate[1]);
   update_solution(&potentialSolution, &solutionUpdate[2]);


### PR DESCRIPTION
Take a look at fasp_to_fenics, I adde the interface for the dcsr and dbsr solvers.

Also look how it is used in tests/linearized_pnp_tests/test_lin_pnp.cpp and tests/faspsolver_tests/test_faspsolve.cpp

The files are shortor, but I removed your getdof and so in the test_lin_pnp.cpp. 