### PR TITLE
modified CMakeLists

### DIFF
--- a/include/newton_functs.h
+++ b/include/newton_functs.h
@@ -60,8 +60,7 @@ void non_dimesionalize_coefficients (domain_param *domain,
 void domain_build (domain_param *domain_par,
            dolfin::Mesh *mesh,
            dolfin::MeshFunction<size_t> *subdomains,
-           dolfin::MeshFunction<size_t> *surfaces,
-           dolfin::File *mesh_output);
+           dolfin::MeshFunction<size_t> *surfaces);
 
 #endif /* end if for __NEWTONFUNCTS_HEADER__ */
 

--- a/src/domains.cpp
+++ b/src/domains.cpp
@@ -34,8 +34,7 @@ using namespace dolfin;
 void domain_build (domain_param *domain_par,
 				           dolfin::Mesh *mesh,
 				           dolfin::MeshFunction<size_t> *subdomains,
-				           dolfin::MeshFunction<size_t> *surfaces,
-                   dolfin::File *mesh_output)
+				           dolfin::MeshFunction<size_t> *surfaces)
 {
 	// no mesh provided: use length and grid parameters
 	if ( strcmp(domain_par->mesh_file,"none")==0 ) {
@@ -73,11 +72,6 @@ void domain_build (domain_param *domain_par,
       dolfin::MeshFunction<std::size_t>  surfaces_object(*mesh, domain_par->surface_file);
       *surfaces = surfaces_object;
     }*/
-
-    *mesh_output << *mesh;
-    *mesh_output << *subdomains;
-    *mesh_output << *surfaces;
-
 }
 
 /*---------------------------------*/

--- a/tests/linearized_pnp_tests/test_lin_pnp.cpp
+++ b/tests/linearized_pnp_tests/test_lin_pnp.cpp
@@ -104,8 +104,7 @@ int main(int argc, char** argv)
   dolfin::Mesh mesh;
   dolfin::MeshFunction<std::size_t> subdomains;
   dolfin::MeshFunction<std::size_t> surfaces;
-  dolfin::File meshOut(domain_par.mesh_output);
-  domain_build(&domain_par, &mesh, &subdomains, &surfaces, &meshOut);
+  domain_build(&domain_par, &mesh, &subdomains, &surfaces);
 
   // read coefficients and boundary values
   if (DEBUG) printf("\tcoefficients...\n");

--- a/tests/linearized_pnp_tests/test_lin_pnp_eafe.cpp
+++ b/tests/linearized_pnp_tests/test_lin_pnp_eafe.cpp
@@ -105,8 +105,7 @@ int main(int argc, char** argv)
   dolfin::Mesh mesh;
   dolfin::MeshFunction<std::size_t> subdomains;
   dolfin::MeshFunction<std::size_t> surfaces;
-  dolfin::File meshOut(domain_par.mesh_output);
-  domain_build(&domain_par, &mesh, &subdomains, &surfaces, &meshOut);
+  domain_build(&domain_par, &mesh, &subdomains, &surfaces);
 
   // read coefficients and boundary values
   if (DEBUG) printf("\tcoefficients...\n");


### PR DESCRIPTION
@arthbous 
when reading in a domain from domain_par.dat, mesh files are automatically output as the mesh is constructed.. This is dumb and will screw up the unit tests in the future.  This PR removes that feature.