### PR TITLE
feature/eafe switch

### DIFF
--- a/benchmarks/PNP/pnp_EAFE.cpp
+++ b/benchmarks/PNP/pnp_EAFE.cpp
@@ -140,7 +140,7 @@ class analyticPotentialExpression : public Expression
 int main (int argc, char** argv)
 {
   if (argc > 1)
-    if (std::string(argv[1])=="EAFE" || std::string(argv[2])=="EAFE")
+    if (std::string(argv[1])=="EAFE")
       eafe_switch = true;
 
   printf("\n-----------------------------------------------------------    ");

--- a/benchmarks/PNP/pnp_EAFE.cpp
+++ b/benchmarks/PNP/pnp_EAFE.cpp
@@ -139,7 +139,7 @@ class analyticPotentialExpression : public Expression
 
 int main (int argc, char** argv)
 {
-  if (argc >1)
+  if (argc > 1)
     if (std::string(argv[1])=="EAFE" || std::string(argv[2])=="EAFE")
       eafe_switch = true;
 
@@ -202,18 +202,6 @@ int main (int argc, char** argv)
   a_pnp.qp = qp; L_pnp.qp = qp;
   a_pnp.qn = qn; L_pnp.qn = qn;
 
-  //EAFE Formulation
-  if (eafe_switch)
-      printf("\tEAFE initializetion...\n");
-  EAFE::FunctionSpace V_cat(mesh);
-  EAFE::BilinearForm a_cat(V_cat,V_cat);
-  a_cat.alpha = Dp;
-  a_cat.gamma = zero;
-  EAFE::FunctionSpace V_an(mesh);
-  EAFE::BilinearForm a_an(V_an,V_an);
-  a_an.alpha = Dn;
-  a_an.gamma = zero;
-
   // analytic solution
   Function analyticSolutionFunction(V);
   Function analyticCation(analyticSolutionFunction[0]);
@@ -274,7 +262,17 @@ int main (int argc, char** argv)
   anionFile << anionSolution;
   potentialFile << potentialSolution;
 
-  // Initialize functions for EAFE
+  //EAFE Formulation
+  if (eafe_switch)
+      printf("\tEAFE initialization...\n");
+  EAFE::FunctionSpace V_cat(mesh);
+  EAFE::BilinearForm a_cat(V_cat,V_cat);
+  a_cat.alpha = Dp;
+  a_cat.gamma = zero;
+  EAFE::FunctionSpace V_an(mesh);
+  EAFE::BilinearForm a_an(V_an,V_an);
+  a_an.alpha = Dn;
+  a_an.gamma = zero;
   Function CatCatFunction(V_cat);
   Function CatBetaFunction(V_cat);
   Function AnAnFunction(V_an);
@@ -344,17 +342,18 @@ int main (int argc, char** argv)
     assemble(A_pnp, a_pnp);
 
     // EAFE expressions
-    CatCatFunction.interpolate(cationSolution);
-    CatBetaFunction.interpolate(potentialSolution);
-    *(CatBetaFunction.vector()) *= coeff_par.cation_valency;
-    *(CatBetaFunction.vector()) += *(CatCatFunction.vector());
-    AnAnFunction.interpolate(anionSolution);
-    AnBetaFunction.interpolate(potentialSolution);
-    *(AnBetaFunction.vector()) *= coeff_par.anion_valency;
-    *(AnBetaFunction.vector()) += *(AnAnFunction.vector());
-
-    // Construct EAFE approximations to Jacobian
     if (eafe_switch) {
+      printf("\tcompute EAFE expressions...\n");
+      CatCatFunction.interpolate(cationSolution);
+      CatBetaFunction.interpolate(potentialSolution);
+      *(CatBetaFunction.vector()) *= coeff_par.cation_valency;
+      *(CatBetaFunction.vector()) += *(CatCatFunction.vector());
+      AnAnFunction.interpolate(anionSolution);
+      AnBetaFunction.interpolate(potentialSolution);
+      *(AnBetaFunction.vector()) *= coeff_par.anion_valency;
+      *(AnBetaFunction.vector()) += *(AnAnFunction.vector());
+
+      // Construct EAFE approximations to Jacobian
       printf("\tconstruct EAFE modifications...\n"); fflush(stdout);
       a_cat.eta = CatCatFunction;
       a_cat.beta = CatBetaFunction;

--- a/benchmarks/PNP/pnp_adaptive.cpp
+++ b/benchmarks/PNP/pnp_adaptive.cpp
@@ -94,7 +94,7 @@ class analyticPotentialExpression : public Expression
 int main(int argc, char** argv)
 {
   if (argc > 1)
-    if (std::string(argv[1])=="EAFE" || std::string(argv[2])=="EAFE")
+    if (std::string(argv[1])=="EAFE")
       eafe_switch = true;
 
   printf("\n-----------------------------------------------------------    ");

--- a/benchmarks/PNP/pnp_adaptive.cpp
+++ b/benchmarks/PNP/pnp_adaptive.cpp
@@ -27,6 +27,8 @@ extern "C"
 using namespace dolfin;
 // using namespace std;
 
+bool eafe_switch = false;
+
 double lower_cation_val = 0.1;  // 1 / m^3
 double upper_cation_val = 1.0;  // 1 / m^3
 double lower_anion_val = 1.0;  // 1 / m^3
@@ -89,12 +91,17 @@ class analyticPotentialExpression : public Expression
 };
 
 
-int main()
+int main(int argc, char** argv)
 {
+  if (argc >1)
+    if (std::string(argv[1])=="EAFE" || std::string(argv[2])=="EAFE")
+      eafe_switch = true;
 
-  printf("\n-----------------------------------------------------------    "); fflush(stdout);
-  printf("\n Solving the linearized Poisson-Nernst-Planck system           "); fflush(stdout);
-  printf("\n of a single cation and anion                                  "); fflush(stdout);
+  printf("\n-----------------------------------------------------------    ");
+  printf("\n Solving the linearized Poisson-Nernst-Planck system           ");
+  printf("\n of a single cation and anion ");
+  if (eafe_switch)
+    printf("using EAFE approximations \n to the Jacobians");
   printf("\n-----------------------------------------------------------\n\n"); fflush(stdout);
 
   // Need to use Eigen for linear algebra
@@ -230,6 +237,8 @@ int main()
     a_pnp.qn = qn; L_pnp.qn = qn;
 
     //EAFE Formulation
+    if (eafe_switch)
+      printf("\tEAFE initializetion...\n");
     EAFE::FunctionSpace V_cat(mesh);
     EAFE::BilinearForm a_cat(V_cat,V_cat);
     a_cat.alpha = Dp;
@@ -366,16 +375,20 @@ int main()
       *(AnBetaFunction.vector()) += *(AnAnFunction.vector());
 
       // Construct EAFE approximations to Jacobian
-      a_cat.eta = CatCatFunction;
-      a_cat.beta = CatBetaFunction;
-      a_an.eta = AnAnFunction;
-      a_an.beta = AnBetaFunction;
-      assemble(A_cat, a_cat);
-      assemble(A_an, a_an);
+      if (eafe_switch) {
+        printf("\tconstruct EAFE modifications...\n"); fflush(stdout);
+        a_cat.eta = CatCatFunction;
+        a_cat.beta = CatBetaFunction;
+        a_an.eta = AnAnFunction;
+        a_an.beta = AnBetaFunction;
+        assemble(A_cat, a_cat);
+        assemble(A_an, a_an);
 
-      // Modify Jacobian
-      replace_matrix(3,0, &V, &V_cat, &A_pnp, &A_cat);
-      replace_matrix(3,1, &V, &V_an , &A_pnp, &A_an );
+        // Modify Jacobian
+        printf("\treplace Jacobian with EAFE approximations...\n"); fflush(stdout);
+        replace_matrix(3,0, &V, &V_cat, &A_pnp, &A_cat);
+        replace_matrix(3,1, &V, &V_an , &A_pnp, &A_an );
+      }
       bc.apply(A_pnp);
 
       // Convert to fasp

--- a/test_all.sh
+++ b/test_all.sh
@@ -19,7 +19,6 @@ make test_replace_matrix
 make test_replace_matrix2
 make test_lin_pnp
 make test_lin_pnp_eafe
-make test_pnp
 make test_pnp_eafe
 make test_newton_param
 
@@ -36,8 +35,8 @@ if [ "$1"=="DEBUG" ]; then
 	./test_replace_matrix2 $1
 	./test_lin_pnp $1
 	./test_lin_pnp_eafe $1
-	./test_pnp $1
 	./test_pnp_eafe $1
+	./test_pnp_eafe $1 EAFE
 	./test_newton_param $1
 else
 	./test_eafe
@@ -49,8 +48,8 @@ else
 	./test_replace_matrix2
 	./test_lin_pnp
 	./test_lin_pnp_eafe
-	./test_pnp
 	./test_pnp_eafe
+	./test_pnp_eafe EAFE
 	./test_newton_param
 fi
 

--- a/tests/matrices_tests/test_add_matrix.cpp
+++ b/tests/matrices_tests/test_add_matrix.cpp
@@ -214,35 +214,6 @@ int main(int argc, char** argv)
   *(solu2.vector())=Solu_vec2;
   *(solu3.vector())=Solu_vec3;
 
-  if (DEBUG){
-    File file1a("./tests/matrices_tests/output_add/Solu_V1.pvd");
-    file1a << solu1;
-    File file1b("./tests/matrices_tests/output_add/SoluExact_V1.pvd");
-    file1b << solu_ex1;
-
-    File file2a("./tests/matrices_tests/output_add/Solu_V2_1.pvd");
-    file2a << solu2[0];
-    File file2b("./tests/matrices_tests/output_add/Solu_V2_2.pvd");
-    file2b << solu2[1];
-    File file2c("./tests/matrices_tests/output_add/SoluExact_V2_1.pvd");
-    file2c << solu_ex2[0];
-    File file2d("./tests/matrices_tests/output_add/SoluExact_V2_2.pvd");
-    file2d << solu_ex2[1];
-
-    File file3a("./tests/matrices_tests/output_add/Solu_V3_1.pvd");
-    file3a << solu3[0];
-    File file3b("./tests/matrices_tests/output_add/Solu_V3_2.pvd");
-    file3b << solu3[1];
-    File file3c("./tests/matrices_tests/output_add/Solu_V3_3.pvd");
-    file3c << solu3[2];
-    File file3d("./tests/matrices_tests/output_add/SoluExact_V3_1.pvd");
-    file3d << solu_ex3[0];
-    File file3e("./tests/matrices_tests/output_add/SoluExact_V3_2.pvd");
-    file3e << solu_ex3[1];
-    File file3f("./tests/matrices_tests/output_add/SoluExact_V3_3.pvd");
-    file3f << solu_ex3[2];
-  }
-
   double error_norm1 = 0.0;
   *(solu_ex1.vector())-=Solu_vec1;
   L2Error::Form_M L2error1(mesh,solu_ex1);

--- a/tests/matrices_tests/test_replace_matrix.cpp
+++ b/tests/matrices_tests/test_replace_matrix.cpp
@@ -214,35 +214,6 @@ int main(int argc, char** argv)
   *(solu2.vector())=Solu_vec2;
   *(solu3.vector())=Solu_vec3;
 
-  if (DEBUG){
-    File file1a("./tests/matrices_tests/output_replace/Solu_V1.pvd");
-    file1a << solu1;
-    File file1b("./tests/matrices_tests/output_replace/SoluExact_V1.pvd");
-    file1b << solu_ex1;
-
-    File file2a("./tests/matrices_tests/output_replace/Solu_V2_1.pvd");
-    file2a << solu2[0];
-    File file2b("./tests/matrices_tests/output_replace/Solu_V2_2.pvd");
-    file2b << solu2[1];
-    File file2c("./tests/matrices_tests/output_replace/SoluExact_V2_1.pvd");
-    file2c << solu_ex2[0];
-    File file2d("./tests/matrices_tests/output_replace/SoluExact_V2_2.pvd");
-    file2d << solu_ex2[1];
-
-    File file3a("./tests/matrices_tests/output_replace/Solu_V3_1.pvd");
-    file3a << solu3[0];
-    File file3b("./tests/matrices_tests/output_replace/Solu_V3_2.pvd");
-    file3b << solu3[1];
-    File file3c("./tests/matrices_tests/output_replace/Solu_V3_3.pvd");
-    file3c << solu3[2];
-    File file3d("./tests/matrices_tests/output_replace/SoluExact_V3_1.pvd");
-    file3d << solu_ex3[0];
-    File file3e("./tests/matrices_tests/output_replace/SoluExact_V3_2.pvd");
-    file3e << solu_ex3[1];
-    File file3f("./tests/matrices_tests/output_replace/SoluExact_V3_3.pvd");
-    file3f << solu_ex3[2];
-  }
-
   double error_norm1 = 0.0;
   *(solu_ex1.vector())-=Solu_vec1;
   L2Error::Form_M L2error1(mesh,solu_ex1);

--- a/tests/matrices_tests/test_replace_matrix2.cpp
+++ b/tests/matrices_tests/test_replace_matrix2.cpp
@@ -261,35 +261,6 @@ int main(int argc, char** argv)
   copy_dvector_to_Function(&solu2_fasp,&solu2);
   copy_dvector_to_Function(&solu3_fasp,&solu3);
 
-  if (DEBUG){
-    File file1a("./tests/matrices_tests/output_replace2/Solu_V1.pvd");
-    file1a << solu1;
-    File file1b("./tests/matrices_tests/output_replace2/SoluExact_V1.pvd");
-    file1b << solu_ex1;
-
-    File file2a("./tests/matrices_tests/output_replace2/Solu_V2_1.pvd");
-    file2a << solu2[0];
-    File file2b("./tests/matrices_tests/output_replace2/Solu_V2_2.pvd");
-    file2b << solu2[1];
-    File file2c("./tests/matrices_tests/output_replace2/SoluExact_V2_1.pvd");
-    file2c << solu_ex2[0];
-    File file2d("./tests/matrices_tests/output_replace2/SoluExact_V2_2.pvd");
-    file2d << solu_ex2[1];
-
-    File file3a("./tests/matrices_tests/output_replace2/Solu_V3_1.pvd");
-    file3a << solu3[0];
-    File file3b("./tests/matrices_tests/output_replace2/Solu_V3_2.pvd");
-    file3b << solu3[1];
-    File file3c("./tests/matrices_tests/output_replace2/Solu_V3_3.pvd");
-    file3c << solu3[2];
-    File file3d("./tests/matrices_tests/output_replace2/SoluExact_V3_1.pvd");
-    file3d << solu_ex3[0];
-    File file3e("./tests/matrices_tests/output_replace2/SoluExact_V3_2.pvd");
-    file3e << solu_ex3[1];
-    File file3f("./tests/matrices_tests/output_replace2/SoluExact_V3_3.pvd");
-    file3f << solu_ex3[2];
-  }
-
   double error_norm1 = 0.0;
   *(solu_ex1.vector())-=*(solu1.vector());
   L2Error::Form_M L2error1(mesh,solu_ex1);


### PR DESCRIPTION
@arthbous (you got pinged)
added eafe switch to ``pnp_adaptivity.cpp``and ``pnp_eafe.cpp`` in ``benchmarks/``.  Now can invoke option EAFE to use the EAFE approximation, where the default option is without EAFE.
e.g. to use EAFE, we can run
```
make pnp_adapt; pnp_adapt EAFE
```
The Newton solver is much faster without the EAFE approximation since the mesh is so coarse in these benchmarks.

Also, made this adjustment to ``test_pnp_eafe.cpp`` so that when we run ``./test_all.sh`` both pnp-tests use the same ``test_pnp_eafe.cpp`` code.  (``test_pnp.cpp`` is not compiled or run in that script anymore, but I'm keeping it there to avoid throwing away potentially useful code.)