### PR TITLE
time-dependent with adaptivity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ output
 cmake_install.cmake
 Makefile
 output/*
+meshOut/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ include_directories(${DOLFIN_INCLUDE_DIRS} ${FASP_INCLUDE_DIR} ${FASP4NS_INCLUDE
 include_directories(SYSTEM ${DOLFIN_3RD_PARTY_INCLUDE_DIRS})
 
 # Awesome OSX TARGET
-# set(OSX_TARGET "/opt/local/lib/gcc49/gcc/x86_64-apple-darwin14/4.9.3/libgcc.a" "/opt/local/lib/gcc49/libquadmath.a" "/opt/local/lib/gcc49/libgfortran.a")
+set(OSX_TARGET "/opt/local/lib/gcc49/gcc/x86_64-apple-darwin14/4.9.3/libgcc.a" "/opt/local/lib/gcc49/libquadmath.a" "/opt/local/lib/gcc49/libgfortran.a")
 
 # Executables
 add_executable(aux_test_reading ./aux/test_reading/aux_test_reading.cpp ${SRC_DIR})


### PR DESCRIPTION
@arthbous 
- renamed some variables.
- only uses 2 meshes (needs five variables: ``initial_cation`` transfers solution over time steps, ``prev_cation_adapt`` transfers prev-solution across meshes, ``cation_adapt`` transfers current solution across meshes.  2 more without the ``*_adapt`` are solves on the current mesh.)
- the function changes over the time-steps which i think wasn't happening before.