### PR TITLE
changed isnan to std::isnan

### DIFF
--- a/benchmarks/PNP/pnp_adaptive.cpp
+++ b/benchmarks/PNP/pnp_adaptive.cpp
@@ -417,7 +417,7 @@ int main(int argc, char** argv)
     }
 
     // check status of Newton solver
-    if (isnan(relative_residual)) {
+    if (std::isnan(relative_residual)) {
       printf("\n### WARNING: Newton solver failed...\n");
       printf("\trelative residual is NaN!!\n\n");
       adaptive_convergence = true;


### PR DESCRIPTION
@maximilianmetti 

Quick fix. pnp_adapt was not compiling because, changed isnan to std::isnan.

(On a other note we should maybe remove the file pnp_EAFE that does nothing)